### PR TITLE
fix(schema.prisma): Remove `shadowDatabaseUrl`

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,14 +10,12 @@ generator client {
 //   provider = "postgresql"
 //   url = env("POSTGRES_PRISMA_URL") // uses connection pooling
 //   directUrl = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
-//   shadowDatabaseUrl = env("POSTGRES_URL_NON_POOLING") // used for migrations
 // }
 
 datasource db {
   provider = "postgresql"
   url = "postgres://default:Ikwx1r8fEQCo@ep-sparkling-waterfall-318696-pooler.ap-southeast-1.postgres.vercel-storage.com/verceldb?pgbouncer=true&connect_timeout=15"
   directUrl = "postgres://default:Ikwx1r8fEQCo@ep-sparkling-waterfall-318696.ap-southeast-1.postgres.vercel-storage.com/verceldb"
-  shadowDatabaseUrl = "postgres://default:Ikwx1r8fEQCo@ep-sparkling-waterfall-318696.ap-southeast-1.postgres.vercel-storage.com/verceldb"
 }
 
 


### PR DESCRIPTION
`shadowDatabaseUrl` is no longer required for Vercel Postgres and may cause issues when set to the same value as `directUrl`.